### PR TITLE
Fix unresponsive bot due to unexpected shutdown

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -5,7 +5,7 @@ module.exports = {
     args   : "start_bot.py", // The Python script to execute
     interpreter : "none", // PM2 should not try to interpret the script itself
     watch  : true, // Restart the app if file changes are detected
-    ignore_watch : ["node_modules", ".git", "*.log", "venv", ".venv", "novels.db"], // Files/folders to ignore when watching
+    ignore_watch : ["node_modules", ".git", "*.log", "venv", ".venv", "novels.db", "novels.db-journal"], // Files/folders to ignore when watching
     exp_backoff_restart_delay: 100 // Delay between restarts in milliseconds
   }]
 };

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -4,7 +4,7 @@ module.exports = {
     script : "./venv/bin/python", // UPDATE WITH ABSOLUTE PATH
     args   : "start_bot.py", // The Python script to execute
     interpreter : "none", // PM2 should not try to interpret the script itself
-    watch  : true, // Restart the app if file changes are detected
+    watch  : false, // Restart the app if file changes are detected
     ignore_watch : ["node_modules", ".git", "*.log", "venv", ".venv", "novels.db", "novels.db-journal"], // Files/folders to ignore when watching
     exp_backoff_restart_delay: 100 // Delay between restarts in milliseconds
   }]


### PR DESCRIPTION
Found the real issue with #7. It turned out pm2 watcher detect a file change every time the db is modified. Preciesly, it detects the changes of `novels.db-journal, a new unrecognized file that's not part of the ignore list. I tried putting it into the watch list but it didn't work. So this PR will simply fix it by turning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Disabled automatic restarts when files change.
  - Updated the list of files and directories ignored during change monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->